### PR TITLE
Makefile changes to work with Vagrant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # make arch=armv7
 
 arch=x86_64
-root=/home/rainbow/word_changer
+root=$(shell pwd)
 name=word_changer
 version=1.0
 

--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,16 @@ arch=x86_64
 root=$(shell pwd)
 name=word_changer
 version=1.0
+build_dir=$(root)/build
 
 build: FORCE
-	sudo rainbow --build $(root) --arch $(arch)
+	sudo rainbow --build $(root) --arch $(arch) --build-dir $(build_dir)
 
 pack:
-	sudo rainbow --pack $(root) --arch $(arch)
+	sudo rainbow --pack $(root) --arch $(arch) --build-dir $(build_dir)
 
 install:
-	sudo rainbow --install $(root)/build/x86_64/com.promptworks.$(name)-$(version)-$(arch).rbw
+	sudo rainbow --install $(build_dir)/x86_64/com.promptworks.$(name)-$(version)-$(arch).rbw
 
 remove:
 	sudo rainbow --remove ${name}
@@ -25,13 +26,13 @@ list:
 	rainbow --list $(name)
 
 send-to-nas:
-	scp build/armv7/com.promptworks.$(name)-$(version)-$(arch).rbw nas:
+	scp $(build_dir)/armv7/com.promptworks.$(name)-$(version)-$(arch).rbw nas:
 
 unmount:
 	sudo umount -l $(root)/build/$(arch)/chroot
 
 clean: FORCE
-	sudo rainbow --clean $(root) --arch $(arch)
+	sudo rainbow --clean $(root) --arch $(arch) --build-dir $(build_dir)
 
 update:
 	make remove && make build && make pack && make install

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install:
 	sudo rainbow --install $(root)/build/x86_64/com.promptworks.$(name)-$(version)-$(arch).rbw
 
 remove:
-	sudo rainbow --remove word_changer
+	sudo rainbow --remove ${name}
 
 list:
 	rainbow --list $(name)

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ root=$(shell pwd)
 name=word_changer
 version=1.0
 build_dir=$(root)/build
+organization=promptworks
 
 build: FORCE
 	sudo rainbow --build $(root) --arch $(arch) --build-dir $(build_dir)
@@ -17,7 +18,7 @@ pack:
 	sudo rainbow --pack $(root) --arch $(arch) --build-dir $(build_dir)
 
 install:
-	sudo rainbow --install $(build_dir)/x86_64/com.promptworks.$(name)-$(version)-$(arch).rbw
+	sudo rainbow --install $(build_dir)/x86_64/com.$(organization).$(name)-$(version)-$(arch).rbw
 
 remove:
 	sudo rainbow --remove ${name}
@@ -26,7 +27,7 @@ list:
 	rainbow --list $(name)
 
 send-to-nas:
-	scp $(build_dir)/armv7/com.promptworks.$(name)-$(version)-$(arch).rbw nas:
+	scp $(build_dir)/armv7/com.$(organization).$(name)-$(version)-$(arch).rbw nas:
 
 unmount:
 	sudo umount -l $(root)/build/$(arch)/chroot


### PR DESCRIPTION
I made a couple changes so that I could use the Makefile with a Vagrant box. 

When the box is brought up, the code for the app is put in a synced folder at `/vagrant`, so I replaced the `root` definition with the current directory of the Makefile.

When on the VM, building fails when rainbow attempts to build into the default directory (`$(root)/build`), so I added a variable for that setting as well. Then, I'm able to successfully build the app with `make build_dir=~/word_changer_build`.
